### PR TITLE
add 'Next' links to bottom of pages in CVMFS section

### DIFF
--- a/docs/cvmfs/flagship-repositories.md
+++ b/docs/cvmfs/flagship-repositories.md
@@ -44,6 +44,9 @@ The [*European Environment for Scientific Software Installations (EESSI)*](https
 of scientific software for `x86_64` (Intel + AMD) and `aarch64` (64-bit Arm) systems that work on any Linux
 distribution.
 
-We will use EESSI as an example repository throughout this tutorial.
+We will use EESSI as an example CernVM-FS repository throughout this tutorial.
 
-More detailed information on EESSI is available in the [next part of this tutorial](../eessi.md).
+
+---
+
+*(next: [What is EESSI?](../eessi/what-is-eessi.md))*

--- a/docs/cvmfs/technical-details.md
+++ b/docs/cvmfs/technical-details.md
@@ -32,3 +32,8 @@ Furthermore, additional caches can be made available to CernVM-FS, such as an
 like GPFS or Lustre that is not managed by CernVM-FS, and a
 [Content Delivery Network (CDN)](https://en.wikipedia.org/wiki/Content_delivery_network)
 can be used to help limit the time required to download files that are not cached yet.
+
+
+---
+
+*(next: [Flagship CernVM-FS repositories](flagship-repositories.md))*

--- a/docs/cvmfs/technical-details.md
+++ b/docs/cvmfs/technical-details.md
@@ -33,7 +33,6 @@ like GPFS or Lustre that is not managed by CernVM-FS, and a
 [Content Delivery Network (CDN)](https://en.wikipedia.org/wiki/Content_delivery_network)
 can be used to help limit the time required to download files that are not cached yet.
 
-
 ---
 
 *(next: [Flagship CernVM-FS repositories](flagship-repositories.md))*

--- a/docs/cvmfs/what-is-cvmfs.md
+++ b/docs/cvmfs/what-is-cvmfs.md
@@ -120,4 +120,4 @@ to distribute the contents of a repository.
 
 ---
 
-For more technical details on how CernVM-FS implements these features, see [here](technical-details.md).
+*(next: [Technical details of CernVM-FS](technical-details.md))*


### PR DESCRIPTION
Preview of updates the landing page being made here is available at https://boegel.github.io/cvmfs-tutorial-hpc-best-practices/ (corresponds to commit 9b3e27e for CernVM-FS section)