### PR TITLE
show basic access to EESSI in section on default repos

### DIFF
--- a/docs/access/client.md
+++ b/docs/access/client.md
@@ -202,6 +202,13 @@ $ find /cvmfs/cvmfs-config.cern.ch/etc/cvmfs -type f -name '*eessi*'
 /cvmfs/cvmfs-config.cern.ch/etc/cvmfs/keys/eessi.io/eessi.io.pub
 ```
 
+That means we now already have access to the EESSI CernVM-FS repository:
+
+```
+$ ls /cvmfs/software.eessi.io
+README.eessi  host_injections  versions
+```
+
 ## Inspecting repository configuration
 
 To check whether a specific CernVM-FS repository is accessible, we can *probe* it:

--- a/docs/eessi/using-eessi.md
+++ b/docs/eessi/using-eessi.md
@@ -13,7 +13,7 @@ Try checking the contents of the `/cvmfs/software.eessi.io` directory with the `
 
 ```bash
 $ ls /cvmfs/software.eessi.io
-host_injections  README  versions
+README.eessi  host_injections  versions
 ```
 
 If you see an error message like "`No such file or directory`", then either the CernVM-FS client


### PR DESCRIPTION
This assumes that https://github.com/EESSI/filesystem-layer/pull/168 is ingested into `software.eessi.io`, which is a pretty safe assumption (*cough* @bedroge *cough*)