### PR TITLE
remove 'Storage backends' page + add collapsed note mentioning use of S3-compatible storage

### DIFF
--- a/docs/access/stratum1.md
+++ b/docs/access/stratum1.md
@@ -107,6 +107,13 @@ recommendations into account:
     [See the CernVM-FS
     documentation](https://cvmfs.readthedocs.io/en/stable/cpt-replica.html#maintenance-processes) for more details.
 
+??? note "Using S3-compatible storage (Amazon S3, Azure Blob, Ceph)"
+
+    CernVM-FS can store data directly to S3-compatible storage systems, such as [Amazon S3](https://aws.amazon.com/s3),
+    [Azure Blob](https://learn.microsoft.com/en-us/azure/storage/blobs), or [Ceph](https://ceph.io).
+
+    For more information, [see the CernVM-FS documentation](https://cvmfs.readthedocs.io/en/stable/cpt-repo.html#sct-s3storagesetup).
+
 ## Setup procedure
 
 To set up a Stratum 1 replica server and configure it to replicate

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -1,5 +1,0 @@
-# Different storage backends for CernVM-FS
-
-## S3
-
-## Tradeoffs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,6 @@ nav:
   - Configuration on HPC systems: configuration_hpc.md
   - Troubleshooting and debugging: troubleshooting.md
   - Performance aspects: performance.md
-  - Storage backends: storage-backends.md
   - Containers: containers.md
   - Creating a CernVM-FS repository: getting-started.md
   - "Appendix: Terminology": appendix/terminology.md


### PR DESCRIPTION
as discussed with CernVM-FS team, not really relevant in context of this tutorial